### PR TITLE
change project name

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2888,9 +2888,9 @@ packages:
   - types-setuptools ; extra == 'types'
   requires_python: '>=3.11'
 - pypi: ./
-  name: xarray-dataclasses
+  name: xarray-dataclass
   version: 1.9.1
-  sha256: e580af753400c9a2c2662341d7392ed04c95e5c17fdb1782fb7c9119ebdf00cf
+  sha256: 7b97496eff2b60946e68f019e1be19f5ed57b784a25d04cd5385138a0ee9ba29
   requires_dist:
   - numpy>=2.0.0,<3
   - typing-extensions>=4.10.0,<5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ reportUnknownVariableType = "warning"
 typeCheckingMode = "strict"
 
 [tool.pixi.pypi-dependencies]
-xarray-dataclasses = { path = ".", editable = true }
+xarray-dataclass = { path = ".", editable = true }
 
 [tool.pixi.dependencies]
 # Allows to specify the pixi conda executable to be able to set the python interpreter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "xarray-dataclasses"
+name = "xarray-dataclass"
 dynamic = ["version"]
 description = "xarray data creation by data classes"
 authors = [


### PR DESCRIPTION
Because of not having received PyPi permissions, the project name is changed to `xarray-dataclass`.

## Summary by Sourcery

Build:
- Update project name in pyproject.toml to xarray-dataclass